### PR TITLE
Document and show account changes and account segments in preview

### DIFF
--- a/assets/readme.md
+++ b/assets/readme.md
@@ -64,8 +64,8 @@ The `changes` object represents all changes to a user that triggered the executi
 
 - `changes.is_new` indicates whether the user created is new and has just been created or not.
 - `changes.segments`, which holds all segments the user has entered and left since the last recompute, accessible via `changes.segments.entered` and `changes.segments.left`. Each segment is an object itself composed of the following properties `created_at` , `id`, `name`, `type`and `updated_at`.
-- `changes.user` which is an object that is exposes each changed attribute as property that value is an array. The array has the old value as the first argument and the new one as the second. For example, if the email is set the first time, you can access it via `changes.user.email` and the value will look like this `[null,` `"``test@hull.io``"``]`.
-- **note** The `account` changes aren't tracked so you won't be able to access them here.
+- `changes.user` which is an object that is exposes each changed attribute as property whose value is an array. The array has the old value as the first argument and the new one as the second. For example, if the email is set the first time, you can access it via `changes.user.email` and the value will look like this `[null, "test@hull.io"]`.
+- `changes.account` which is an object that is exposes each changed attribute as property whose value is an array. The array has the old value as the first argument and the new one as the second. For example, if the email is set the first time, you can access it via `changes.account.domain` and the value will look like this `[null,"www.hull.io"]`
 
 The following code shows an example of changes:
 
@@ -88,10 +88,30 @@ The following code shows an example of changes:
             // omitted for brevity
           ]
         },
+        account_segments: {
+          entered: [
+            {
+              created_at: "2017-09-01 09:30:22.458Z",
+              id: "dfbdd69d-1e6d-4a58-8031-c721a88f71f6",
+              name: "All Accounts",
+              type: "account",
+              updated_at: "2017-09-01 10:04:01.938Z",
+            },
+            // more segments if applicable
+          ],
+          left: [
+            // omitted for brevity
+          ]
+        },
         user: {
           newsletter_subscribed: [false, true],
           first_name: [null, "John"],
           last_name: [null, "Doe"]
+        }
+        account: {
+          name: [null, "Hull"],
+          domain: [null, "www.hull.io"],
+          mrr: [null, "500"]
         }
       }
     }

--- a/assets/readme.md
+++ b/assets/readme.md
@@ -64,7 +64,7 @@ The `changes` object represents all changes to a user that triggered the executi
 
 - `changes.is_new` indicates whether the user created is new and has just been created or not.
 - `changes.segments`, which holds all segments the user has entered and left since the last recompute, accessible via `changes.segments.entered` and `changes.segments.left`. Each segment is an object itself composed of the following properties `created_at` , `id`, `name`, `type`and `updated_at`.
-- `changes.user` which is an object that is exposes each changed attribute as property whose value is an array. The array has the old value as the first argument and the new one as the second. For example, if the email is set the first time, you can access it via `changes.user.email` and the value will look like this `[null, "test@hull.io"]`.
+- `changes.user` which is an object that exposes each changed attribute as a property. The property value is an array which has the old value as the first argument and the new one as the second. For example, if the email is set the first time, you can access it via `changes.user.email` and the value will look like this `[null, "test@hull.io"]`.
 - `changes.account` which is an object that is exposes each changed attribute as property whose value is an array. The array has the old value as the first argument and the new one as the second. For example, if the email is set the first time, you can access it via `changes.account.domain` and the value will look like this `[null,"www.hull.io"]`
 
 The following code shows an example of changes:

--- a/server/middlewares/fetch-user.js
+++ b/server/middlewares/fetch-user.js
@@ -194,7 +194,7 @@ module.exports = function fetchUser(req, res, next) {
       const grouped_user = client.utils.groupTraits(payload.user);
       const account = client.utils.groupTraits(grouped_user.account);
       const changes = {
-        account: getSample(account),
+        account: getSample(payload.user.account),
         user: getSample(payload.user),
         is_new: false,
         segments: {


### PR DESCRIPTION
This PR ensures we display the following data in the Code Editor's preview:

- `changes.accounts`
- `changes.account_segments`
- `account_segments`

Those were previously available in the payloads but not presented in the Preview screen.